### PR TITLE
Give higher priority to child capsules

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,9 +118,35 @@ val primary = Capsule(common) {
 
 val test = Capsule(common) {
     // Register dependencies which you may only want to use in tests. This should preferably
-    // be set up in such way that it cannot be accessible from your regular code, only be your tests
+    // be set up in such way that it cannot be accessible from your regular code, only by your tests
 }
 ```
+
+Dependencies in a child module will always have higher priority than dependencies in a parent module.
+
+```kotlin
+import java.time.Clock
+import java.time.Instant
+
+val parent = Capsule {
+    register<Clock> {
+        Clock.systemUTC()
+    }
+}
+
+val child = Capsule(parent) {
+    // This Clock will have priority over the Clock registered in the parent
+    register<Clock> {
+        Clock.fixed(Instant.EPOCH)
+    }
+}
+
+// This will always return the Clock that returns an `Instant.EPOCH`
+val clock: Clock = child.get()
+```
+
+This means that it is possible to register all your "real" dependencies in one module and then only override the ones
+that needs to be different in tests with other implementations.
 
 Sometimes you need all implementations of an interfaces. For such cases you can use `getMany`.
 

--- a/lib/src/main/kotlin/io/nexure/capsule/Capsule.kt
+++ b/lib/src/main/kotlin/io/nexure/capsule/Capsule.kt
@@ -45,18 +45,18 @@ private constructor(
 
     class Configuration
     internal constructor(
-        val priority: Int,
+        private val priority: Int,
         internal val dependencies: LinkedList<Dependency>,
     ) : Capsule(priority, dependencies) {
-        inline fun <reified T : Any> register(priority: Int = this.priority, noinline setup: () -> T) {
+        inline fun <reified T : Any> register(noinline setup: () -> T) {
             val clazz: Class<T> = T::class.java
-            register(clazz, priority, setup)
+            register(clazz, setup)
             clazz.interfaces.forEach {
-                register(it, priority, setup)
+                register(it, setup)
             }
         }
 
-        fun <T : Any> register(clazz: Class<out T>, priority: Int = DEFAULT_PRIORITY, setup: () -> T) {
+        fun <T : Any> register(clazz: Class<out T>, setup: () -> T) {
             val dependency = Dependency.fromClass(clazz, priority, setup)
             dependencies.push(dependency)
         }

--- a/lib/src/test/kotlin/io/nexure/capsule/CapsuleTest.kt
+++ b/lib/src/test/kotlin/io/nexure/capsule/CapsuleTest.kt
@@ -130,6 +130,37 @@ class CapsuleTest {
         val greeters: List<Greeter> = capsule.getMany()
         assertEquals(2, greeters.size)
     }
+
+    @Test
+    fun `test implicit inherited priority`() {
+        val first = Capsule {
+            register<Greeter> {
+                object : Greeter {
+                    override fun hello(): String = "1"
+                }
+            }
+        }
+
+        val second = Capsule(first) {
+            register<Greeter> {
+                object : Greeter {
+                    override fun hello(): String = "2"
+                }
+            }
+        }
+
+        val third = Capsule(second) {
+            register<Greeter> {
+                object : Greeter {
+                    override fun hello(): String = "3"
+                }
+            }
+        }
+
+        val greeter: Greeter = third.get()
+        assertEquals("3", greeter.hello())
+        assertEquals(listOf("3", "2", "1"), third.getMany<Greeter>().map { it.hello() })
+    }
 }
 
 interface Greeter {


### PR DESCRIPTION
Change priority of dependencies for inherited capsules, so dependencies registered in child capsules will always have higher priority (be used first) over dependencies in parent capsules.